### PR TITLE
Some styling changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,27 +114,29 @@ It is now possible to create paginated collections on demand in your twig file. 
 ### Basic usage
 
 ```twig
-{% set collection = << some collection >> %}
-{% set limit = << number of items per page >> %}
+{# some collection #}
+{% set collection = page.collection() %}
+{# number of items per page #}
+{% set limit = 5 %}
 {% do paginate( collection, limit ) %}
 ```
 
-This creates a paginated collection with << limit >> items per page. As usual, any url parameters - except the page parameter, which is recreated - are passed on to the pagination bar's links.
+This creates a paginated collection with `limit` items per page. As usual, any url parameters - except the page parameter, which is recreated - are passed on to the pagination bar's links.
 
 ### Extended usage
 
 ```twig
-{% set collection = page.find( '/other/_events' ).children %}
+{% set collection = page.find('/other/_events').children %}
 {% set limit = 5 %}
-{% set ignore_url_param_array = [ 'event' ] %}
-{% do paginate( collection, limit, ignore_url_param_array ) %}
+{% set ignore_url_param_array = ['event'] %}
+{% do paginate(collection, limit, ignore_url_param_array) %}
 ```
 
-The above example is taken from http://ami-web.nl/events. This code creates a paginated collection with 5 items per page (the event summary list) which is presented together with an active event. The active event appears in only one of the summary pages. Consequently, the url parameter 'event' should be filtered out so it does not show up in the pagination bar's links, preventing inconsistencies with different page parameters. Any non listed url parameters (except the page parameter) are passed through unaffected. The requested page contains logic to pick a sensible default event.
+The above example is taken from http://ami-web.nl/events. This code creates a paginated collection with 5 items per page (the event summary list) which is presented together with an active event. The active event appears in only one of the summary pages. Consequently, the url parameter `event` should be filtered out so it does not show up in the pagination bar's links, preventing inconsistencies with different page parameters. Any non listed url parameters (except the page parameter) are passed through unaffected. The requested page contains logic to pick a sensible default event.
 
 ### Rendering the paginated collection
 
-The rest is identical to the standard procedure.
+The rest is identical to the standard procedure:
 
 ```twig
 {# create list of items #}


### PR DESCRIPTION
I don't know how correctly set placeholders like this in twig:
```twig
{% set collection = << some collection >> %}
```

So I use twig comments and defaults:
```twig
{# some collection #}
{% set collection = page.collection() %}
```